### PR TITLE
Update procedure for fastq filter

### DIFF
--- a/sketchy/terminal/fq_filter/commands.py
+++ b/sketchy/terminal/fq_filter/commands.py
@@ -1,43 +1,68 @@
 import click
 import pandas
+import pysam
+import sys
 
 from pathlib import Path
 from sketchy.utils import filter_fastq
 
+
 @click.command()
 @click.option(
-    '--fpath', '-f', type=Path, help='Path to Fastq file to select from.'
+    "--fpath",
+    "-f",
+    type=Path,
+    help="Path to Fast{a,q} file to select from.",
+    required=True,
 )
 @click.option(
-    '--output', '-o', type=Path, help='Output to Fastq file.'
+    "--output",
+    "-o",
+    type=str,
+    help="Output to Fast{a,q} file. Default stdout [-]",
+    default="-",
 )
 @click.option(
-    '--ids', '-i', type=Path,
-    help='Path to file containing the read '
-         'IDs to select in second column.'
+    "--ids",
+    "-i",
+    type=Path,
+    help=(
+        "Path to file containing the read IDs to get from fast{a,q}. "
+        "A header line is expected."
+    ),
+    required=True,
 )
 @click.option(
-    '--column', '-c', default=1,
-    help='Column index that contains the IDs.'
+    "--column",
+    "-c",
+    default=1,
+    help="Column index that contains the IDs (0-based). [1]",
+    type=int,
 )
 @click.option(
-    '--sep', '-s', default='\t',
-    help='File separator to read columns.'
+    "--sep",
+    "-s",
+    default="\t",
+    help="File separator to read columns. ['\\t']",
+    type=str,
 )
-def fq_filter(fpath, ids, output, column, sep):
+def fq_filter(fpath: Path, ids: Path, output: str, column: int, sep: str):
     """ Filter reads by headers; used for species grep (sketchy.nf) """
+    if output == "-":
+        output = sys.stdout
+    else:
+        p = Path(output)
+        if not p.parent.is_dir():
+            raise NotADirectoryError(
+                "Directory specified for output file does not exist: {}".format(
+                    p.parent
+                )
+            )
+        output = p.open("w")
 
     ids_df = pandas.read_csv(ids, sep=sep)
-    read_ids = [str(_) for _ in ids_df.iloc[:, column].tolist()]
+    read_ids = set([str(read_id) for read_id in ids_df.iloc[:, column].tolist()])
 
-    filter_fastq(fpath=fpath, output=output, records=read_ids)
-
-
-
-
-
-
-
-
-
-
+    with pysam.FastxFile(fpath) as fastq_in:
+        filter_fastq(fastq_in=fastq_in, fastq_out=output, records=read_ids)
+    output.close()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,109 @@
+from io import StringIO
+import tempfile
+import pysam
+from sketchy.utils import *
+
+
+def create_tmp_fastq(contents: str) -> pysam.FastxFile:
+    with tempfile.NamedTemporaryFile(mode="r+") as tmp:
+        tmp.write(contents)
+        tmp.truncate()
+        return pysam.FastxFile(tmp.name)
+
+
+def test_filterFastq_emptyFileWritesEmpty():
+    contents = ""
+    fastq = create_tmp_fastq(contents)
+    output = StringIO()
+    records = {"foo"}
+
+    filter_fastq(fastq, output, records)
+    output.seek(0)
+    actual = output.read()
+    expected = ""
+
+    assert actual == expected
+
+
+def test_filterFastq_invalidFormatWritesEmpty():
+    contents = "I am not a correctly formatted file!"
+    fastq = create_tmp_fastq(contents)
+    output = StringIO()
+    records = {"foo"}
+
+    filter_fastq(fastq, output, records)
+    output.seek(0)
+    actual = output.read()
+    expected = ""
+
+    assert actual == expected
+
+
+def test_filterFastq_noRequestedRecordsWritesEmpty():
+    contents = "@read1\nATGC\n+\n$$$$\n"
+    fastq = create_tmp_fastq(contents)
+    output = StringIO()
+    records = {"read2"}
+
+    filter_fastq(fastq, output, records)
+    output.seek(0)
+    actual = output.read()
+    expected = ""
+
+    assert actual == expected
+
+
+def test_filterFastq_oneRequestedRecordsWritesOneRecord():
+    contents = "@read1\nATGC\n+\n$$$$\n"
+    fastq = create_tmp_fastq(contents)
+    output = StringIO()
+    records = {"read1"}
+
+    filter_fastq(fastq, output, records)
+    output.seek(0)
+    actual = output.read()
+    expected = contents
+
+    assert actual == expected
+
+
+def test_filterFastq_oneRequestedRecordOneNotRequestedWritesOnlyRequested():
+    contents = "@read1\nATGC\n+\n$$$$\n@read2\nATCC\n+\n$!$$\n"
+    fastq = create_tmp_fastq(contents)
+    output = StringIO()
+    records = {"read2"}
+
+    filter_fastq(fastq, output, records)
+    output.seek(0)
+    actual = output.read()
+    expected = "@read2\nATCC\n+\n$!$$\n"
+
+    assert actual == expected
+
+
+def test_filterFastq_twoRequestedRecordOneNotRequestedWritesOnlyRequested():
+    contents = "@read1\nATGC\n+\n$$$$\n@read2\nATCC\n+\n$!$$\n@read3\nGGGG\n+\n$$$$\n"
+    fastq = create_tmp_fastq(contents)
+    output = StringIO()
+    records = {"read1", "read3"}
+
+    filter_fastq(fastq, output, records)
+    output.seek(0)
+    actual = output.read()
+    expected = "@read1\nATGC\n+\n$$$$\n@read3\nGGGG\n+\n$$$$\n"
+
+    assert actual == expected
+
+
+def test_filterFastq_fastaIsAlsoParsed():
+    contents = ">read1\nATGC\n>read2\nATCC\n>read3\nGGGG\n\n"
+    fastq = create_tmp_fastq(contents)
+    output = StringIO()
+    records = {"read1", "read3"}
+
+    filter_fastq(fastq, output, records)
+    output.seek(0)
+    actual = output.read()
+    expected = ">read1\nATGC\n>read3\nGGGG\n"
+
+    assert actual == expected


### PR DESCRIPTION
* Replace fastq filter to use `pysam` API for handling records. This also means we can seamlessly parse fasta too.
* Add tests for the filter fastq function.
* Some small changes to CLI for `fq-filter`

Closes #20 