### PR TITLE
Fix local conda build recipe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
-mkdir -p $PREFIX/bin
+#!/bin/bash
+set -x
+export RUST_BACKTRACE=full
 
-cargo build --release
-mv target/release/sketchy $PREFIX/bin/sketchy-rs
+cargo install -v --locked --root "$PREFIX" --path .
 
-$PYTHON -m pip install .
+"$PYTHON" -m pip install --no-deps --ignore-installed -vv .

--- a/meta.yaml
+++ b/meta.yaml
@@ -3,14 +3,14 @@
 
 # conda build -c esteinig -c bioconda -c conda-forge .
 package:
-  name: {{ name }}
-  version: {{ version }}
+  name:               {{ name }}
+  version:            {{ version }}
 
 source:
-    path: .
+  path:               .
 
 build:
-  number: 0
+  number:             0
   entry_points:
     - sketchy = sketchy.terminal.client:terminal_client
 
@@ -51,10 +51,10 @@ test:
     - sketchy-rs -h
 
 about:
-  home: https://github.com/esteinig/sketchy
-  license: MIT
-  license_file: LICENSE
-  summary: 'Real-time lineage hashing and genotyping of bacterial pathogens'
+  home:               https://github.com/esteinig/sketchy
+  license:            MIT
+  license_file:       LICENSE
+  summary:            'Real-time lineage hashing and genotyping of bacterial pathogens'
 
 extra:
   recipe-maintainers:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,27 +1,28 @@
 {% set version = "0.4.3" %}
+{% set name = "sketchy" %}
 
 # conda build -c esteinig -c bioconda -c conda-forge .
-
 package:
-  name: sketchy
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  path: .
+    path: .
 
 build:
-  number: 1
+  number: 0
+  entry_points:
+    - sketchy = sketchy.terminal.client:terminal_client
 
 requirements:
   build:
       - {{ compiler('cxx') }}
+      - rust >=1.39
   host:
-      - python>=3.7
-      - rust>=1.39
+      - python ==3.7
   run:
-      - python>=3.7
-      - rust>=1.39
-      - mash=2.2
+      - python ==3.7
+      - mash ==2.2
       - wget
       - nextflow
       - tqdm
@@ -41,6 +42,7 @@ requirements:
       - networkx
       - pyfastx
       - watchdog
+      - dendropy
 test:
   imports:
     - sketchy
@@ -49,8 +51,12 @@ test:
     - sketchy-rs -h
 
 about:
-  home: 'https://github.com/esteinig/sketchy'
+  home: https://github.com/esteinig/sketchy
   license: MIT
   license_file: LICENSE
   summary: 'Real-time lineage hashing and genotyping of bacterial pathogens'
 
+extra:
+  recipe-maintainers:
+    - esteinig
+    - mbhall88


### PR DESCRIPTION
Addresses building local conda package using recipe files [#33].

In addition, https://github.com/bioconda/bioconda-recipes/pull/20642 creates a bioconda package for distribution.